### PR TITLE
added a way to control flushing when the app becomes inactive

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -129,6 +129,18 @@
  @property
 
  @abstract
+ Control whether the library should keep on flushing data to Mixpanel when the app
+ isn't active anymore.
+
+ @discussion
+ Defaults to NO. This can be useful if your app does things while being "inactive".
+ */
+@property(nonatomic,assign) BOOL flushOnInactive;
+
+/*!
+ @property
+
+ @abstract
  Controls whether to show spinning network activity indicator when flushing
  data to the Mixpanel servers.
 

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -350,6 +350,7 @@ static Mixpanel *sharedInstance = nil;
         self.apiToken = apiToken;
         self.flushInterval = flushInterval;
         self.flushOnBackground = YES;
+        self.flushOnInactive = YES;
         self.showNetworkActivityIndicator = YES;
         self.serverURL = @"https://api.mixpanel.com";
         
@@ -903,8 +904,12 @@ static Mixpanel *sharedInstance = nil;
 - (void)applicationWillResignActive:(NSNotification *)notification
 {
     MixpanelDebug(@"%@ application will resign active", self);
-    @synchronized(self) {
+    if (self.flushOnInactive) {
+      MixpanelDebug(@"Keep on flushing even though the application won't be active.");
+    } else {
+      @synchronized(self) {
         [self stopFlushTimer];
+      }
     }
 }
 


### PR DESCRIPTION
This change is needed if you run an OS X app that does things in the background.
