### PR TITLE
Fixing registering notifications on OS X

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -172,7 +172,7 @@ static Mixpanel *sharedInstance = nil;
         }
 #endif
         
-#ifndef TARGET_OS_IPHONE
+#if TARGET_OS_MAC
         [notificationCenter addObserver:self
                                selector:@selector(applicationWillTerminate:)
                                    name:NSApplicationWillTerminateNotification


### PR DESCRIPTION
TARGET_OS_IPHONE is always defined, so notifications were never registered.