### PR TITLE
Fixed compilation issue on Cocoapods 1.0

### DIFF
--- a/Mixpanel-OSX-Community.podspec
+++ b/Mixpanel-OSX-Community.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         =  'Mixpanel-OSX-Community'
-  s.version      =  '2.1.0'
+  s.version      =  '2.1.1'
   s.license      =  'Apache License'
   s.summary      =  'OS X tracking library for Mixpanel Analytics.'
   s.homepage     =  'http://mixpanel.com'

--- a/Mixpanel-OSX-Community.podspec
+++ b/Mixpanel-OSX-Community.podspec
@@ -10,4 +10,5 @@ Pod::Spec.new do |s|
   s.platform     =  :osx
   s.source_files =  'Mixpanel/**/*.{h,m}'
   s.requires_arc = true
+  s.osx.deployment_target = '10.7'
 end


### PR DESCRIPTION
Cocoapods 1.0's default target is too old and the project doesn't compile.
The solution is to set a default target in the podspec and then it works.
